### PR TITLE
Fix: kafka-connect | rm duplicate env vars

### DIFF
--- a/charts/cp-kafka-connect/Chart.yaml
+++ b/charts/cp-kafka-connect/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Kafka Connect on Kubernetes
 name: cp-kafka-connect
-version: 0.2.5
+version: 0.2.6

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -78,12 +78,18 @@ spec:
               value: {{ template "cp-kafka-connect.kafka.bootstrapServers" . }}
             - name: CONNECT_GROUP_ID
               value: {{ template "cp-kafka-connect.groupId" . }}
+            {{ if not (hasKey .Values.configurationOverrides "config.storage.topic") }}
             - name: CONNECT_CONFIG_STORAGE_TOPIC
               value: {{ template "cp-kafka-connect.fullname" . }}-config
+            {{ end }}
+            {{ if not (hasKey .Values.configurationOverrides "offset.storage.topic") }}
             - name: CONNECT_OFFSET_STORAGE_TOPIC
               value: {{ template "cp-kafka-connect.fullname" . }}-offset
+            {{ end }}
+            {{ if not (hasKey .Values.configurationOverrides "status.storage.topic") }}
             - name: CONNECT_STATUS_STORAGE_TOPIC
               value: {{ template "cp-kafka-connect.fullname" . }}-status
+            {{ end }}
             - name: CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL
               value: {{ template "cp-kafka-connect.cp-schema-registry.service-name" .}}
             - name: CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL


### PR DESCRIPTION
## What changes were proposed in this pull request?

remove making of duplicate env vars in charts

https://uxi.atlassian.net/browse/BEP-1700
