### PR TITLE
feat: enable liveness probes without script

### DIFF
--- a/charts/cp-kafka-connect/Chart.yaml
+++ b/charts/cp-kafka-connect/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Kafka Connect on Kubernetes
 name: cp-kafka-connect
-version: 0.2.6
+version: 0.2.7

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -116,11 +116,11 @@ spec:
               /etc/confluent/docker/run &
               $CUSTOM_SCRIPT_PATH
               sleep infinity
+        {{- end }}
           {{- if .Values.livenessProbe }}
           livenessProbe:
 {{ toYaml .Values.livenessProbe | trim | indent 12 }}
           {{- end }}
-        {{- end }}
           {{- if .Values.volumeMounts }}
           volumeMounts:
 {{ toYaml .Values.volumeMounts | indent 10 }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This should enable us to make use of the liveness probes so that pods don't start accepting traffic until they are ready. To avoid this:

https://sentry.io/organizations/aruba-uxi/issues/3442000229/?project=5795196&query=is%3Aunresolved&statsPeriod=7d

## How was this patch tested?

(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)
