### PR TITLE
feat: Readiness Probes for kafka connect

### DIFF
--- a/charts/cp-kafka-connect/Chart.yaml
+++ b/charts/cp-kafka-connect/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Kafka Connect on Kubernetes
 name: cp-kafka-connect
-version: 0.2.7
+version: 0.3.0

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -121,6 +121,10 @@ spec:
           livenessProbe:
 {{ toYaml .Values.livenessProbe | trim | indent 12 }}
           {{- end }}
+          {{- if .Values.readinessProbe }}
+          readinessProbe:
+{{ toYaml .Values.readinessProbe | trim | indent 12 }}
+          {{- end }}
           {{- if .Values.volumeMounts }}
           volumeMounts:
 {{ toYaml .Values.volumeMounts | indent 10 }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -130,6 +130,14 @@ livenessProbe:
   # periodSeconds: 5
   # failureThreshold: 10
 
+readinessProbe:
+  # httpGet:
+  #   path: /connectors
+  #   port: 8083
+  # initialDelaySeconds: 30
+  # periodSeconds: 5
+  # failureThreshold: 10
+
 serviceAccount:
   name: ""
   annotations: {}


### PR DESCRIPTION
## What changes were proposed in this pull request?

This will allow us to specify readiness probes too

## How was this patch tested?

(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)
