### PR TITLE
feat: exposed datadog.jmx.max_returned_metrics as config option & clean up

### DIFF
--- a/charts/cp-kafka-connect/Chart.yaml
+++ b/charts/cp-kafka-connect/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Kafka Connect on Kubernetes
 name: cp-kafka-connect
-version: 0.4.9
+version: 0.4.10

--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -65,14 +65,19 @@ kissing-macaw-cp-kafka-connect-6c77b8f5fd-cqlzq  1/1    Running  0         34m
 ```
 
 There are
-1. A [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) `kissing-macaw-cp-kafka-connect` which contains 1 Kafka Connect [Pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/): `kissing-macaw-cp-kafka-connect-6c77b8f5fd-cqlzq`.
-2. A [Service](https://kubernetes.io/docs/concepts/services-networking/service/) `kissing-macaw-cp-kafka-connect` for clients to connect to Kafka Connect REST endpoint.
+
+1. A [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) 
+   `kissing-macaw-cp-kafka-connect` which contains 1 Kafka Connect [Pod](https://kubernetes.
+   io/docs/concepts/workloads/pods/pod-overview/): `kissing-macaw-cp-kafka-connect-6c77b8f5fd-cqlzq`.
+2. A [Service](https://kubernetes.io/docs/concepts/services-networking/service/) 
+   `kissing-macaw-cp-kafka-connect` for clients to connect to Kafka Connect REST endpoint.
 
 ## Configuration
 
 You can specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+Alternatively, a YAML file that specifies the values for the parameters can be provided while
+installing the chart. For example,
 
 ```console
 helm install --name my-kafka-connect -f my-values.yaml ./cp-kafka-connect
@@ -82,110 +87,113 @@ helm install --name my-kafka-connect -f my-values.yaml ./cp-kafka-connect
 
 ### Kafka Connect Deployment
 
-The configuration parameters in this section control the resources requested and utilized by the `cp-kafka-connect` chart.
+The configuration parameters in this section control the resources requested and utilized by
+the `cp-kafka-connect` chart.
 
-| Parameter         | Description                           | Default   |
-| ----------------- | ------------------------------------- | --------- |
-| `replicaCount`    | The number of Kafka Connect Servers.  | `1`       |
+| Parameter      | Description                          | Default |
+|----------------|--------------------------------------|---------|
+| `replicaCount` | The number of Kafka Connect Servers. | `1`     |
 
 ### Image
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `image` | Docker Image of Confluent Kafka Connect. | `confluentinc/cp-kafka-connect` |
-| `imageTag` | Docker Image Tag of Confluent Kafka Connect. | `6.1.0` |
-| `imagePullPolicy` | Docker Image Tag of Confluent Kafka Connect. | `IfNotPresent` |
-| `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
+| Parameter          | Description                                  | Default                                    |
+|--------------------|----------------------------------------------|--------------------------------------------|
+| `image`            | Docker Image of Confluent Kafka Connect.     | `confluentinc/cp-kafka-connect`            |
+| `imageTag`         | Docker Image Tag of Confluent Kafka Connect. | `6.1.0`                                    |
+| `imagePullPolicy`  | Docker Image Tag of Confluent Kafka Connect. | `IfNotPresent`                             |
+| `imagePullSecrets` | Secrets to be used for private registries.   | see [values.yaml](values.yaml) for details |
 
 ### Port
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `servicePort` | The port on which the Kafka Connect will be available and serving requests. | `8083` |
+| Parameter     | Description                                                                 | Default |
+|---------------|-----------------------------------------------------------------------------|---------|
+| `servicePort` | The port on which the Kafka Connect will be available and serving requests. | `8083`  |
 
 ### Kafka Connect Worker Configurations
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `configurationOverrides` | Kafka Connect [configuration](https://docs.confluent.io/current/connect/references/allconfigs.html) overrides in the dictionary format. | `{}` |
-| `customEnv` | Custom environmental variables | `{}` |
+| Parameter                | Description                                                                                                                             | Default |
+|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `configurationOverrides` | Kafka Connect [configuration](https://docs.confluent.io/current/connect/references/allconfigs.html) overrides in the dictionary format. | `{}`    |
+| `customEnv`              | Custom environmental variables                                                                                                          | `{}`    |
 
 ### Volumes
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `volumes` | Volumes for connect-server container | see [values.yaml](values.yaml) for details |
+| Parameter      | Description                                | Default                                    |
+|----------------|--------------------------------------------|--------------------------------------------|
+| `volumes`      | Volumes for connect-server container       | see [values.yaml](values.yaml) for details |
 | `volumeMounts` | Volume mounts for connect-server container | see [values.yaml](values.yaml) for details |
 
 ### Secrets
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
+| Parameter | Description                               | Default                                    |
+|-----------|-------------------------------------------|--------------------------------------------|
 | `secrets` | Secret with one or more `key:value` pairs | see [values.yaml](values.yaml) for details |
 
 ### Kafka Connect JVM Heap Options
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
+| Parameter     | Description                            | Default               |
+|---------------|----------------------------------------|-----------------------|
 | `heapOptions` | The JVM Heap Options for Kafka Connect | `"-Xms512M -Xmx512M"` |
 
 ### Resources
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `resources.requests.cpu` | The amount of CPU to request. | see [values.yaml](values.yaml) for details |
-| `resources.requests.memory` | The amount of memory to request. | see [values.yaml](values.yaml) for details |
-| `resources.requests.limit` | The upper limit CPU usage for a Kafka Connect Pod. | see [values.yaml](values.yaml) for details |
-| `resources.requests.limit` | The upper limit memory usage for a Kafka Connect Pod. | see [values.yaml](values.yaml) for details |
+| Parameter                   | Description                                           | Default                                    |
+|-----------------------------|-------------------------------------------------------|--------------------------------------------|
+| `resources.requests.cpu`    | The amount of CPU to request.                         | see [values.yaml](values.yaml) for details |
+| `resources.requests.memory` | The amount of memory to request.                      | see [values.yaml](values.yaml) for details |
+| `resources.requests.limit`  | The upper limit CPU usage for a Kafka Connect Pod.    | see [values.yaml](values.yaml) for details |
+| `resources.requests.limit`  | The upper limit memory usage for a Kafka Connect Pod. | see [values.yaml](values.yaml) for details |
 
 ### Annotations
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `podAnnotations` | Map of custom annotations to attach to the pod spec. | `{}` |
+| Parameter        | Description                                          | Default |
+|------------------|------------------------------------------------------|---------|
+| `podAnnotations` | Map of custom annotations to attach to the pod spec. | `{}`    |
 
 ### JMX Configuration
 
-| Parameter     | Description                           | Default |
-|---------------|---------------------------------------|---------|
-| `jmx.enabled` | Whether or not to expose JMX metrics. | `false` |
+| Parameter     | Description                                       | Default |
+|---------------|---------------------------------------------------|---------|
+| `jmx.enabled` | Whether or not to expose JMX metrics.             | `false` |
 | `jmx.port`    | The jmx port which JMX style metrics are exposed. | `5555`  |
 
 ### Prometheus JMX Exporter Configuration
 
-| Parameter                        | Description | Default                                                            |
-|----------------------------------| ----------- |--------------------------------------------------------------------|
+| Parameter                        | Description                                                                                                    | Default                                                            |
+|----------------------------------|----------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
 | `jmx.prometheus.enabled`         | Whether or not to install Prometheus JMX Exporter as a sidecar container and expose JMX metrics to Prometheus. | `false`                                                            |
-| `jmx.prometheus.image`           | Docker Image for Prometheus JMX Exporter container. | `solsson/kafka-prometheus-jmx-exporter@sha256`                     |
-| `jmx.prometheus.imageTag`        | Docker Image Tag for Prometheus JMX Exporter container. | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
-| `jmx.prometheus.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container. | `IfNotPresent`                                                     |
-| `jmx.prometheus.port`            | JMX Exporter Port which exposes metrics in Prometheus format for scraping. | `5556`                                                             |
-| `jmx.prometheus.resources`       | JMX Exporter resources configuration. | see [values.yaml](values.yaml) for details                         |
+| `jmx.prometheus.image`           | Docker Image for Prometheus JMX Exporter container.                                                            | `solsson/kafka-prometheus-jmx-exporter@sha256`                     |
+| `jmx.prometheus.imageTag`        | Docker Image Tag for Prometheus JMX Exporter container.                                                        | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
+| `jmx.prometheus.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container.                                                | `IfNotPresent`                                                     |
+| `jmx.prometheus.port`            | JMX Exporter Port which exposes metrics in Prometheus format for scraping.                                     | `5556`                                                             |
+| `jmx.prometheus.resources`       | JMX Exporter resources configuration.                                                                          | see [values.yaml](values.yaml) for details                         |
 
-### Datadog JMX Exporter Configuration
+### Datadog Configuration
 
-| Parameter                        | Description                                                                                              | Default |
-|----------------------------------|----------------------------------------------------------------------------------------------------------|---------|
-| `jmx.datadog.enabled`            | Whether or not to annotate the pod for autodiscovery by the Datadog agent expose JMX metrics to Datadog. | `false` |
+| Parameter                          | Description                                                                                                 | Default |
+|------------------------------------|-------------------------------------------------------------------------------------------------------------|---------|
+| `datadog.jmx.enabled`              | Whether or not to annotate the pod for autodiscovery by the Datadog agent to expose JMX metrics to Datadog. | `false` |
+| `datadog.jmx.max_returned_metrics` | The maximum number of JMX metrics to send to Datadog.                                                       | `false` |
+| `datadog.logs.enabled`             | Whether or not to annotate the pod for autodiscovery by the Datadog agent to send logs to Datadog.          | `false` |
 
 ### Running Custom Scripts
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `customEnv.CUSTOM_SCRIPT_PATH` | Path to external bash script to run inside the container | see [values.yaml](values.yaml) for details |
-| `livenessProbe` | Requirement of `livenessProbe` depends on the custom script to be run  | see [values.yaml](values.yaml) for details |
+| Parameter                      | Description                                                           | Default                                    |
+|--------------------------------|-----------------------------------------------------------------------|--------------------------------------------|
+| `customEnv.CUSTOM_SCRIPT_PATH` | Path to external bash script to run inside the container              | see [values.yaml](values.yaml) for details |
+| `livenessProbe`                | Requirement of `livenessProbe` depends on the custom script to be run | see [values.yaml](values.yaml) for details |
 
 ### Deployment Topology
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `nodeSelector` | Dictionary containing key-value-pairs to match labels on nodes. When defined pods will only be scheduled on nodes, that have each of the indicated key-value pairs as labels. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}`
-| `tolerations`| Array containing taint references. When defined, pods can run on nodes, which would otherwise deny scheduling. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `{}`
+| Parameter      | Description                                                                                                                                                                                                                                                                                                          | Default |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `nodeSelector` | Dictionary containing key-value-pairs to match labels on nodes. When defined pods will only be scheduled on nodes, that have each of the indicated key-value pairs as labels. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}`    |
+| `tolerations`  | Array containing taint references. When defined, pods can run on nodes, which would otherwise deny scheduling. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)                                                           | `{}`    |
 
 ## Dependencies
 
 ### Kafka
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `kafka.bootstrapServers` | Bootstrap Servers for Kafka Connect | `""` |
+| Parameter                | Description                         | Default |
+|--------------------------|-------------------------------------|---------|
+| `kafka.bootstrapServers` | Bootstrap Servers for Kafka Connect | `""`    |

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       labels:
         app: {{ template "cp-kafka-connect.name" . }}
         release: {{ .Release.Name }}
-      {{- if or .Values.podAnnotations .Values.jmx.prometheus.enabled .Values.jmx.datadog.enabled }}
+      {{- if or .Values.podAnnotations .Values.jmx.prometheus.enabled .Values.datadog.jmx.enabled .Values.datadog.logs.enabled}}
       annotations:
       {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
@@ -31,7 +31,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.jmx.prometheus.port | quote }}
       {{- end }}
-      {{- if .Values.jmx.datadog.enabled }}
+      {{- if .Values.datadog.jmx.enabled }}
         ad.datadoghq.com/{{ template "cp-kafka-connect.fullname" . }}.check_names: '["confluent_platform"]'
         ad.datadoghq.com/{{ template "cp-kafka-connect.fullname" . }}.init_configs: '[{"is_jmx":true,"collect_default_metrics":true}]'
         ad.datadoghq.com/{{ template "cp-kafka-connect.fullname" . }}.instances: |
@@ -39,12 +39,12 @@ spec:
             {
               "host":"%%host%%",
               "port":{{ .Values.jmx.port | quote }},
-              "max_returned_metrics":999
+              "max_returned_metrics":{{.Values.datadog.jmx.max_returned_metrics}}
             }
           ]
-        {{- if .Values.jmx.datadog.logs.enabled }}
+      {{- end }}
+      {{- if .Values.datadog.logs.enabled }}
         ad.datadoghq.com/{{ template "cp-kafka-connect.fullname" . }}.logs: '[{"source":"confluent_platform","service":"confluent_platform"}]'
-        {{- end }}
       {{- end }}
       {{- end }}
     spec:

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -90,8 +90,12 @@ jmx:
     ## Resources configuration for the JMX exporter container.
     ## See the `resources` documentation above for details.
     resources: { }
-  datadog:
-    enabled: false
+
+# Datadog Configuration
+datadog:
+    jmx:
+      enabled: false
+      max_returned_metrics: 9999
     logs:
       enabled: false
 

--- a/charts/cp-kafka-rest/Chart.yaml
+++ b/charts/cp-kafka-rest/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Kafka REST Proxy on Kubernetes
 name: cp-kafka-rest
-version: 0.1.6
+version: 0.1.7

--- a/charts/cp-kafka-rest/README.md
+++ b/charts/cp-kafka-rest/README.md
@@ -68,16 +68,26 @@ hopping-salamander-cp-kafka-rest-jmx-configmap  1     1s
 ```
 
 There are
-1. A [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) `hopping-salamander-cp-kafka-rest` which contains 1 REST Proxy [Pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/): `hopping-salamander-cp-kafka-rest-67b86cff98-qxrd8`.
-1. A [Service](https://kubernetes.io/docs/concepts/services-networking/service/) `hopping-salamander-cp-kafka-rest` for clients to connect to REST Proxy.
-1. A [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) which contains configuration for Prometheus JMX Exporter.
-1. (Optional) A [Service](https://kubernetes.io/docs/concepts/services-networking/service/) `hopping-salamander-cp-kafka-restproxy-external` for clients to connect to REST Proxy from outside.
+
+1.
+A [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) `hopping-salamander-cp-kafka-rest`
+which contains 1 REST
+Proxy [Pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/): `hopping-salamander-cp-kafka-rest-67b86cff98-qxrd8`.
+1.
+A [Service](https://kubernetes.io/docs/concepts/services-networking/service/) `hopping-salamander-cp-kafka-rest`
+for clients to connect to REST Proxy.
+1. A [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/)
+   which contains configuration for Prometheus JMX Exporter.
+1. (Optional)
+   A [Service](https://kubernetes.io/docs/concepts/services-networking/service/) `hopping-salamander-cp-kafka-restproxy-external`
+   for clients to connect to REST Proxy from outside.
 
 ## Configuration
 
 You can specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+Alternatively, a YAML file that specifies the values for the parameters can be provided while
+installing the chart. For example,
 
 ```console
 helm install --name my-rest-proxy -f my-values.yaml ./cp-kafka-rest
@@ -87,109 +97,113 @@ helm install --name my-rest-proxy -f my-values.yaml ./cp-kafka-rest
 
 ### REST Proxy Deployment
 
-The configuration parameters in this section control the resources requested and utilized by the `cp-kafka-rest` chart.
+The configuration parameters in this section control the resources requested and utilized by
+the `cp-kafka-rest` chart.
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `replicaCount` | The number of REST Proxy Servers. | `1` |
+| Parameter      | Description                       | Default |
+|----------------|-----------------------------------|---------|
+| `replicaCount` | The number of REST Proxy Servers. | `1`     |
 
 ### Image
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `image` | Docker Image of Confluent REST Proxy. | `confluentinc/cp-kafka-rest` |
-| `imageTag` | Docker Image Tag of Confluent REST Proxy. | `6.1.0` |
-| `imagePullPolicy` | Docker Image Tag of Confluent REST Proxy. | `IfNotPresent` |
+| Parameter          | Description                                | Default                                    |
+|--------------------|--------------------------------------------|--------------------------------------------|
+| `image`            | Docker Image of Confluent REST Proxy.      | `confluentinc/cp-kafka-rest`               |
+| `imageTag`         | Docker Image Tag of Confluent REST Proxy.  | `6.1.0`                                    |
+| `imagePullPolicy`  | Docker Image Tag of Confluent REST Proxy.  | `IfNotPresent`                             |
 | `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
 
 ### Port
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `servicePort` | The port on which the REST Proxy will be available and serving requests. | `8082` |
+| Parameter     | Description                                                              | Default |
+|---------------|--------------------------------------------------------------------------|---------|
+| `servicePort` | The port on which the REST Proxy will be available and serving requests. | `8082`  |
 
 ### Confluent Kafka REST Configuration
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `configurationOverrides` | Kafka REST [configuration](https://docs.confluent.io/current/kafka-rest/docs/config.html) overrides in the dictionary format | `{}` |
-| `customEnv` | Custom environmental variables | `{}` |
+| Parameter                | Description                                                                                                                  | Default |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------------|---------|
+| `configurationOverrides` | Kafka REST [configuration](https://docs.confluent.io/current/kafka-rest/docs/config.html) overrides in the dictionary format | `{}`    |
+| `customEnv`              | Custom environmental variables                                                                                               | `{}`    |
 
 ### Confluent Kafka REST JVM Heap Options
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
+| Parameter     | Description                                   | Default               |
+|---------------|-----------------------------------------------|-----------------------|
 | `heapOptions` | The JVM Heap Options for Confluent Kafka REST | `"-Xms512M -Xmx512M"` |
 
 ### Resources
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `resources.requests.cpu` | The amount of CPU to request. | see [values.yaml](values.yaml) for details |
-| `resources.requests.memory` | The amount of memory to request. | see [values.yaml](values.yaml) for details |
-| `resources.requests.limit` | The upper limit CPU usage for a REST Proxy Pod. | see [values.yaml](values.yaml) for details |
-| `resources.requests.limit` | The upper limit memory usage for a REST Proxy Pod. | see [values.yaml](values.yaml) for details |
+| Parameter                   | Description                                        | Default                                    |
+|-----------------------------|----------------------------------------------------|--------------------------------------------|
+| `resources.requests.cpu`    | The amount of CPU to request.                      | see [values.yaml](values.yaml) for details |
+| `resources.requests.memory` | The amount of memory to request.                   | see [values.yaml](values.yaml) for details |
+| `resources.requests.limit`  | The upper limit CPU usage for a REST Proxy Pod.    | see [values.yaml](values.yaml) for details |
+| `resources.requests.limit`  | The upper limit memory usage for a REST Proxy Pod. | see [values.yaml](values.yaml) for details |
 
 ### Annotations
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `podAnnotations` | Map of custom annotations to attach to the pod spec. | `{}` |
+| Parameter        | Description                                          | Default |
+|------------------|------------------------------------------------------|---------|
+| `podAnnotations` | Map of custom annotations to attach to the pod spec. | `{}`    |
 
 ### JMX Configuration
 
-| Parameter     | Description                           | Default |
-|---------------|---------------------------------------|---------|
-| `jmx.enabled` | Whether or not to expose JMX metrics. | `false` |
+| Parameter     | Description                                       | Default |
+|---------------|---------------------------------------------------|---------|
+| `jmx.enabled` | Whether or not to expose JMX metrics.             | `false` |
 | `jmx.port`    | The jmx port which JMX style metrics are exposed. | `5555`  |
 
 ### Prometheus JMX Exporter Configuration
 
-| Parameter                        | Description | Default                                                            |
-|----------------------------------| ----------- |--------------------------------------------------------------------|
+| Parameter                        | Description                                                                                                    | Default                                                            |
+|----------------------------------|----------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
 | `jmx.prometheus.enabled`         | Whether or not to install Prometheus JMX Exporter as a sidecar container and expose JMX metrics to Prometheus. | `false`                                                            |
-| `jmx.prometheus.image`           | Docker Image for Prometheus JMX Exporter container. | `solsson/kafka-prometheus-jmx-exporter@sha256`                     |
-| `jmx.prometheus.imageTag`        | Docker Image Tag for Prometheus JMX Exporter container. | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
-| `jmx.prometheus.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container. | `IfNotPresent`                                                     |
-| `jmx.prometheus.port`            | JMX Exporter Port which exposes metrics in Prometheus format for scraping. | `5556`                                                             |
-| `jmx.prometheus.resources`       | JMX Exporter resources configuration. | see [values.yaml](values.yaml) for details                         |
+| `jmx.prometheus.image`           | Docker Image for Prometheus JMX Exporter container.                                                            | `solsson/kafka-prometheus-jmx-exporter@sha256`                     |
+| `jmx.prometheus.imageTag`        | Docker Image Tag for Prometheus JMX Exporter container.                                                        | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
+| `jmx.prometheus.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container.                                                | `IfNotPresent`                                                     |
+| `jmx.prometheus.port`            | JMX Exporter Port which exposes metrics in Prometheus format for scraping.                                     | `5556`                                                             |
+| `jmx.prometheus.resources`       | JMX Exporter resources configuration.                                                                          | see [values.yaml](values.yaml) for details                         |
 
-### Datadog JMX Exporter Configuration
 
-| Parameter                        | Description                                                                                              | Default |
-|----------------------------------|----------------------------------------------------------------------------------------------------------|---------|
-| `jmx.datadog.enabled`            | Whether or not to annotate the pod for autodiscovery by the Datadog agent expose JMX metrics to Datadog. | `false` |
+### Datadog Configuration
+
+| Parameter                          | Description                                                                                                 | Default |
+|------------------------------------|-------------------------------------------------------------------------------------------------------------|---------|
+| `datadog.jmx.enabled`              | Whether or not to annotate the pod for autodiscovery by the Datadog agent to expose JMX metrics to Datadog. | `false` |
+| `datadog.jmx.max_returned_metrics` | The maximum number of JMX metrics to send to Datadog.                                                       | `false` |
+| `datadog.logs.enabled`             | Whether or not to annotate the pod for autodiscovery by the Datadog agent to send logs to Datadog.          | `false` |
 
 ### External Access
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `external.enabled` | whether or not to allow external access to Kafka REST Proxy | `false` |
-| `external.type` | `Kubernetes Service Type` to expose Kafka REST Proxy to external | `LoadBalancer` |
-| `external.port` | External service port to expose Kafka REST Proxy to external | `8082` |
-| `external.annotations` | Map of annotations to attach to external Kafka REST Proxy service | `nil` |
-| `external.externalTrafficPolicy` | Configures `.spec.externalTrafficPolicy` which controls if load balancing occurs across all nodes (value of `Cluster`) or only active nodes (value of `Local`)  | `Cluster` |
-| `external.loadBalancerSourceRanges` | Configures `.spec.loadBalancerSourceRanges` which controls a list of source IP ranges permitted access to the load balancer | `["0.0.0.0/0"]` |
+| Parameter                           | Description                                                                                                                                                    | Default         |
+|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| `external.enabled`                  | whether or not to allow external access to Kafka REST Proxy                                                                                                    | `false`         |
+| `external.type`                     | `Kubernetes Service Type` to expose Kafka REST Proxy to external                                                                                               | `LoadBalancer`  |
+| `external.port`                     | External service port to expose Kafka REST Proxy to external                                                                                                   | `8082`          |
+| `external.annotations`              | Map of annotations to attach to external Kafka REST Proxy service                                                                                              | `nil`           |
+| `external.externalTrafficPolicy`    | Configures `.spec.externalTrafficPolicy` which controls if load balancing occurs across all nodes (value of `Cluster`) or only active nodes (value of `Local`) | `Cluster`       |
+| `external.loadBalancerSourceRanges` | Configures `.spec.loadBalancerSourceRanges` which controls a list of source IP ranges permitted access to the load balancer                                    | `["0.0.0.0/0"]` |
 
 ### Deployment Topology
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `nodeSelector` | Dictionary containing key-value-pairs to match labels on nodes. When defined pods will only be scheduled on nodes, that have each of the indicated key-value pairs as labels. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}`
-| `tolerations`| Array containing taint references. When defined, pods can run on nodes, which would otherwise deny scheduling. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `{}`
+| Parameter      | Description                                                                                                                                                                                                                                                                                                          | Default |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `nodeSelector` | Dictionary containing key-value-pairs to match labels on nodes. When defined pods will only be scheduled on nodes, that have each of the indicated key-value pairs as labels. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}`    |
+| `tolerations`  | Array containing taint references. When defined, pods can run on nodes, which would otherwise deny scheduling. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)                                                           | `{}`    |
 
 ## Dependencies
 
 ### Zookeeper
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `cp-zookeeper.url` | Service name of Zookeeper cluster (Not needed if this is installed along with cp-kafka chart). | `""` |
-| `cp-zookeeper.clientPort` | Port of Zookeeper Cluster | `2181` |
+| Parameter                 | Description                                                                                    | Default |
+|---------------------------|------------------------------------------------------------------------------------------------|---------|
+| `cp-zookeeper.url`        | Service name of Zookeeper cluster (Not needed if this is installed along with cp-kafka chart). | `""`    |
+| `cp-zookeeper.clientPort` | Port of Zookeeper Cluster                                                                      | `2181`  |
 
 ### Schema Registry (optional)
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `cp-schema-registry.url` | Service name of Schema Registry (Not needed if this is installed along with cp-kafka chart). | `""` |
-| `cp-schema-registry.port` | Port of Schema Registry Service | `8081` |
+| Parameter                 | Description                                                                                  | Default |
+|---------------------------|----------------------------------------------------------------------------------------------|---------|
+| `cp-schema-registry.url`  | Service name of Schema Registry (Not needed if this is installed along with cp-kafka chart). | `""`    |
+| `cp-schema-registry.port` | Port of Schema Registry Service                                                              | `8081`  |

--- a/charts/cp-kafka-rest/templates/deployment.yaml
+++ b/charts/cp-kafka-rest/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       labels:
         app: {{ template "cp-kafka-rest.name" . }}
         release: {{ .Release.Name }}
-      {{- if or .Values.podAnnotations .Values.jmx.prometheus.enabled .Values.jmx.datadog.enabled }}
+      {{- if or .Values.podAnnotations .Values.jmx.prometheus.enabled .Values.datadog.jmx.enabled .Values.datadog.logs.enabled}}
       annotations:
       {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
@@ -31,7 +31,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.jmx.prometheus.port | quote }}
       {{- end }}
-      {{- if .Values.jmx.datadog.enabled }}
+      {{- if .Values.datadog.jmx.enabled }}
         ad.datadoghq.com/{{ template "cp-kafka-rest.fullname" . }}.check_names: '["confluent_platform"]'
         ad.datadoghq.com/{{ template "cp-kafka-rest.fullname" . }}.init_configs: '[{"is_jmx":true,"collect_default_metrics":true}]'
         ad.datadoghq.com/{{ template "cp-kafka-rest.fullname" . }}.instances: |
@@ -39,12 +39,12 @@ spec:
             {
               "host":"%%host%%",
               "port":{{ .Values.jmx.port | quote }},
-              "max_returned_metrics":999
+              "max_returned_metrics":{{.Values.datadog.jmx.max_returned_metrics}}
             }
           ]
-        {{- if .Values.jmx.datadog.logs.enabled }}
+      {{- end }}
+      {{- if .Values.datadog.logs.enabled }}
         ad.datadoghq.com/{{ template "cp-kafka-rest.fullname" . }}.logs: '[{"source":"confluent_platform","service":"confluent_platform"}]'
-        {{- end }}
       {{- end }}
       {{- end }}
     spec:

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -80,8 +80,12 @@ jmx:
     ## Resources configuration for the JMX exporter container.
     ## See the `resources` documentation above for details.
     resources: { }
-  datadog:
-    enabled: false
+
+# Datadog Configuration
+datadog:
+    jmx:
+      enabled: false
+      max_returned_metrics: 999
     logs:
       enabled: false
 

--- a/charts/cp-ksql-server/Chart.yaml
+++ b/charts/cp-ksql-server/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent KSQL Server on Kubernetes
 name: cp-ksql-server
-version: 0.1.5
+version: 0.1.6

--- a/charts/cp-ksql-server/README.md
+++ b/charts/cp-ksql-server/README.md
@@ -4,7 +4,8 @@ This chart bootstraps a deployment of a Confluent KSQL Server.
 
 This is an example deployment which runs KSQL Server in non-interactive
 mode.
-The included queries file `queries.sql` is a stub provided to illustrate one possible approach to mounting queries in the server container via ConfigMap.
+The included queries file `queries.sql` is a stub provided to illustrate one possible approach to
+mounting queries in the server container via ConfigMap.
 
 ## Prerequisites
 
@@ -78,16 +79,29 @@ https://docs.confluent.io/current/ksql/docs
 ```
 
 There are
-1. A [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) `excited-lynx-cp-ksql-server` which contains 1 KSQL Server instance [Pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/): `excited-lynx-cp-ksql-server-d4848ff94-x5fmn`.
-1. A [Service](https://kubernetes.io/docs/concepts/services-networking/service/) `excited-lynx-cp-ksql-server` for clients to connect to KSQL Server.
-1. A [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) which contains configuration for Prometheus JMX Exporter.
-1. A [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) which contains SQL queries for the server to run in non-interactive mode.
+
+1.
+
+A [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) `excited-lynx-cp-ksql-server`
+which contains 1 KSQL Server
+instance [Pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/): `excited-lynx-cp-ksql-server-d4848ff94-x5fmn`.
+
+1.
+
+A [Service](https://kubernetes.io/docs/concepts/services-networking/service/) `excited-lynx-cp-ksql-server`
+for clients to connect to KSQL Server.
+
+1. A [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/)
+   which contains configuration for Prometheus JMX Exporter.
+1. A [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/)
+   which contains SQL queries for the server to run in non-interactive mode.
 
 ## Configuration
 
 You can specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+Alternatively, a YAML file that specifies the values for the parameters can be provided while
+installing the chart. For example,
 
 ```console
 helm install --name my-ksql-server -f my-values.yaml ./cp-ksql-server
@@ -97,100 +111,104 @@ helm install --name my-ksql-server -f my-values.yaml ./cp-ksql-server
 
 ### KSQL Server Deployment
 
-The configuration parameters in this section control the resources requested and utilized by the cp-ksql-server chart.
+The configuration parameters in this section control the resources requested and utilized by the
+cp-ksql-server chart.
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `replicaCount` | The number of KSQL Server instances. | `1` |
+| Parameter      | Description                          | Default |
+|----------------|--------------------------------------|---------|
+| `replicaCount` | The number of KSQL Server instances. | `1`     |
 
 ### Image
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `image` | Docker Image of Confluent KSQL Server. | `confluentinc/cp-ksql-server` |
-| `imageTag` | Docker Image Tag of Confluent KSQL Server. | `6.1.0` |
-| `imagePullPolicy` | Docker Image Tag of Confluent KSQL Server. | `IfNotPresent` |
+| Parameter          | Description                                | Default                                    |
+|--------------------|--------------------------------------------|--------------------------------------------|
+| `image`            | Docker Image of Confluent KSQL Server.     | `confluentinc/cp-ksql-server`              |
+| `imageTag`         | Docker Image Tag of Confluent KSQL Server. | `6.1.0`                                    |
+| `imagePullPolicy`  | Docker Image Tag of Confluent KSQL Server. | `IfNotPresent`                             |
 | `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
 
 ### KSQL Configuration
- Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `configurationOverrides` | KSQL [configuration](https://docs.confluent.io/current/ksql/docs/installation/server-config/config-reference.html) overrides in the dictionary format | `{}` |
+
+| Parameter                | Description                                                                                                                                           | Default |
+|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `configurationOverrides` | KSQL [configuration](https://docs.confluent.io/current/ksql/docs/installation/server-config/config-reference.html) overrides in the dictionary format | `{}`    |
 
 ### Port
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `servicePort` | The port on which the KSQL Server will be available and serving requests. | `8088` |
+| Parameter     | Description                                                               | Default |
+|---------------|---------------------------------------------------------------------------|---------|
+| `servicePort` | The port on which the KSQL Server will be available and serving requests. | `8088`  |
 
 ### KSQL JVM Heap Options
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
+| Parameter     | Description                   | Default               |
+|---------------|-------------------------------|-----------------------|
 | `heapOptions` | The JVM Heap Options for KSQL | `"-Xms512M -Xmx512M"` |
 
 ### Resources
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `resources.requests.cpu` | The amount of CPU to request. | see [values.yaml](values.yaml) for details |
-| `resources.requests.memory` | The amount of memory to request. | see [values.yaml](values.yaml) for details |
-| `resources.requests.limit` | The upper limit CPU usage for a KSQL Server Pod. | see [values.yaml](values.yaml) for details |
-| `resources.requests.limit` | The upper limit memory usage for a KSQL Server Pod. | see [values.yaml](values.yaml) for details |
+| Parameter                   | Description                                         | Default                                    |
+|-----------------------------|-----------------------------------------------------|--------------------------------------------|
+| `resources.requests.cpu`    | The amount of CPU to request.                       | see [values.yaml](values.yaml) for details |
+| `resources.requests.memory` | The amount of memory to request.                    | see [values.yaml](values.yaml) for details |
+| `resources.requests.limit`  | The upper limit CPU usage for a KSQL Server Pod.    | see [values.yaml](values.yaml) for details |
+| `resources.requests.limit`  | The upper limit memory usage for a KSQL Server Pod. | see [values.yaml](values.yaml) for details |
 
 ### Annotations
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `podAnnotations` | Map of custom annotations to attach to the pod spec. | `{}` |
+| Parameter        | Description                                          | Default |
+|------------------|------------------------------------------------------|---------|
+| `podAnnotations` | Map of custom annotations to attach to the pod spec. | `{}`    |
 
 ### JMX Configuration
 
-| Parameter     | Description                           | Default |
-|---------------|---------------------------------------|---------|
-| `jmx.enabled` | Whether or not to expose JMX metrics. | `false` |
+| Parameter     | Description                                       | Default |
+|---------------|---------------------------------------------------|---------|
+| `jmx.enabled` | Whether or not to expose JMX metrics.             | `false` |
 | `jmx.port`    | The jmx port which JMX style metrics are exposed. | `5555`  |
 
 ### Prometheus JMX Exporter Configuration
 
-| Parameter                        | Description | Default                                                            |
-|----------------------------------| ----------- |--------------------------------------------------------------------|
+| Parameter                        | Description                                                                                                    | Default                                                            |
+|----------------------------------|----------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
 | `jmx.prometheus.enabled`         | Whether or not to install Prometheus JMX Exporter as a sidecar container and expose JMX metrics to Prometheus. | `false`                                                            |
-| `jmx.prometheus.image`           | Docker Image for Prometheus JMX Exporter container. | `solsson/kafka-prometheus-jmx-exporter@sha256`                     |
-| `jmx.prometheus.imageTag`        | Docker Image Tag for Prometheus JMX Exporter container. | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
-| `jmx.prometheus.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container. | `IfNotPresent`                                                     |
-| `jmx.prometheus.port`            | JMX Exporter Port which exposes metrics in Prometheus format for scraping. | `5556`                                                             |
-| `jmx.prometheus.resources`       | JMX Exporter resources configuration. | see [values.yaml](values.yaml) for details                         |
+| `jmx.prometheus.image`           | Docker Image for Prometheus JMX Exporter container.                                                            | `solsson/kafka-prometheus-jmx-exporter@sha256`                     |
+| `jmx.prometheus.imageTag`        | Docker Image Tag for Prometheus JMX Exporter container.                                                        | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
+| `jmx.prometheus.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container.                                                | `IfNotPresent`                                                     |
+| `jmx.prometheus.port`            | JMX Exporter Port which exposes metrics in Prometheus format for scraping.                                     | `5556`                                                             |
+| `jmx.prometheus.resources`       | JMX Exporter resources configuration.                                                                          | see [values.yaml](values.yaml) for details                         |
 
-### Datadog JMX Exporter Configuration
+### Datadog Configuration
 
-| Parameter                        | Description                                                                                              | Default |
-|----------------------------------|----------------------------------------------------------------------------------------------------------|---------|
-| `jmx.datadog.enabled`            | Whether or not to annotate the pod for autodiscovery by the Datadog agent expose JMX metrics to Datadog. | `false` |
+| Parameter                          | Description                                                                                                 | Default |
+|------------------------------------|-------------------------------------------------------------------------------------------------------------|---------|
+| `datadog.jmx.enabled`              | Whether or not to annotate the pod for autodiscovery by the Datadog agent to expose JMX metrics to Datadog. | `false` |
+| `datadog.jmx.max_returned_metrics` | The maximum number of JMX metrics to send to Datadog.                                                       | `false` |
+| `datadog.logs.enabled`             | Whether or not to annotate the pod for autodiscovery by the Datadog agent to send logs to Datadog.          | `false` |
 
 ### External Access
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `external.enabled` | whether or not to allow external access to KSQL Server | `false` |
-| `external.type` | `Kubernetes Service Type` to expose KSQL Server to external | `LoadBalancer` |
-| `external.port` | External service port to expose KSQL Server to external | `8082` |
-| `external.annotations` | Map of annotations to attach to external KSQL Server service | `nil` |
-| `external.externalTrafficPolicy` | Configures `.spec.externalTrafficPolicy` which controls if load balancing occurs across all nodes (value of `Cluster`) or only active nodes (value of `Local`)  | `Cluster` |
-| `external.loadBalancerSourceRanges` | Configures `.spec.loadBalancerSourceRanges` which specifies the list of source IP ranges permitted access to the load balancer | `["0.0.0.0/0"]` |
+| Parameter                           | Description                                                                                                                                                    | Default         |
+|-------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| `external.enabled`                  | whether or not to allow external access to KSQL Server                                                                                                         | `false`         |
+| `external.type`                     | `Kubernetes Service Type` to expose KSQL Server to external                                                                                                    | `LoadBalancer`  |
+| `external.port`                     | External service port to expose KSQL Server to external                                                                                                        | `8082`          |
+| `external.annotations`              | Map of annotations to attach to external KSQL Server service                                                                                                   | `nil`           |
+| `external.externalTrafficPolicy`    | Configures `.spec.externalTrafficPolicy` which controls if load balancing occurs across all nodes (value of `Cluster`) or only active nodes (value of `Local`) | `Cluster`       |
+| `external.loadBalancerSourceRanges` | Configures `.spec.loadBalancerSourceRanges` which specifies the list of source IP ranges permitted access to the load balancer                                 | `["0.0.0.0/0"]` |
 
 ### Deployment Topology
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `nodeSelector` | Dictionary containing key-value-pairs to match labels on nodes. When defined pods will only be scheduled on nodes, that have each of the indicated key-value pairs as labels. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}`
-| `tolerations`| Array containing taint references. When defined, pods can run on nodes, which would otherwise deny scheduling. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `{}`
+| Parameter      | Description                                                                                                                                                                                                                                                                                                          | Default |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `nodeSelector` | Dictionary containing key-value-pairs to match labels on nodes. When defined pods will only be scheduled on nodes, that have each of the indicated key-value pairs as labels. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}`    |
+| `tolerations`  | Array containing taint references. When defined, pods can run on nodes, which would otherwise deny scheduling. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)                                                           | `{}`    |
 
 ## Dependencies
 
 ### Schema Registry (optional)
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `cp-schema-registry.url` | Service name of Schema Registry (Not needed if this is installed along with cp-kafka chart). | `""` |
-| `cp-schema-registry.port` | Port of Schema Registry Service | `8081` |
+| Parameter                 | Description                                                                                  | Default |
+|---------------------------|----------------------------------------------------------------------------------------------|---------|
+| `cp-schema-registry.url`  | Service name of Schema Registry (Not needed if this is installed along with cp-kafka chart). | `""`    |
+| `cp-schema-registry.port` | Port of Schema Registry Service                                                              | `8081`  |

--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       labels:
         app: {{ template "cp-ksql-server.name" . }}
         release: {{ .Release.Name }}
-      {{- if or .Values.podAnnotations .Values.jmx.prometheus.enabled .Values.jmx.datadog.enabled }}
+      {{- if or .Values.podAnnotations .Values.jmx.prometheus.enabled .Values.datadog.jmx.enabled .Values.datadog.logs.enabled}}
       annotations:
       {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
@@ -31,7 +31,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.jmx.prometheus.port | quote }}
       {{- end }}
-      {{- if .Values.jmx.datadog.enabled }}
+      {{- if .Values.datadog.jmx.enabled }}
         ad.datadoghq.com/{{ template "cp-ksql-server.fullname" . }}.check_names: '["confluent_platform"]'
         ad.datadoghq.com/{{ template "cp-ksql-server.fullname" . }}.init_configs: '[{"is_jmx":true,"collect_default_metrics":true}]'
         ad.datadoghq.com/{{ template "cp-ksql-server.fullname" . }}.instances: |
@@ -39,12 +39,12 @@ spec:
             {
               "host":"%%host%%",
               "port":{{ .Values.jmx.port | quote }},
-              "max_returned_metrics":999
+              "max_returned_metrics": {{.Values.datadog.jmx.max_returned_metrics}}
             }
           ]
-        {{- if .Values.jmx.datadog.logs.enabled }}
+      {{- end }}
+      {{- if .Values.datadog.logs.enabled }}
         ad.datadoghq.com/{{ template "cp-ksql-server.fullname" . }}.logs: '[{"source":"confluent_platform","service":"confluent_platform"}]'
-        {{- end }}
       {{- end }}
       {{- end }}
     spec:

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -72,10 +72,14 @@ jmx:
     ## Resources configuration for the JMX exporter container.
     ## See the `resources` documentation above for details.
     resources: { }
-  datadog:
+
+# Datadog configuration
+datadog:
+  jmx:
     enabled: false
-    logs:
-      enabled: false
+    max_returned_metrics: 9999
+  logs:
+    enabled: false
 
 
 ## External Access

--- a/charts/cp-schema-registry/Chart.yaml
+++ b/charts/cp-schema-registry/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Schema Registry on Kubernetes
 name: cp-schema-registry
-version: 0.1.4
+version: 0.1.5

--- a/charts/cp-schema-registry/README.md
+++ b/charts/cp-schema-registry/README.md
@@ -39,9 +39,11 @@ helm install --set kafka.bootstrapServers="PLAINTEXT://unhinged-robin-cp-kafka-h
 ```
 
 ### Installed Components
+
 You can use `helm status <release name>` to view all of the installed components.
 
 For example:
+
 ```console{%raw}
 $ helm status lolling-chinchilla
 NAMESPACE: default
@@ -66,15 +68,27 @@ lolling-chinchilla-cp-schema-registry-jmx-configmap  1     1s
 ```
 
 There are
-1. A [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) `lolling-chinchilla-cp-schema-registry` which contains 1 Schema Registry [Pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/): `lolling-chinchilla-cp-schema-registry-58f854bd47-jxrcj`.
-1. A [Service](https://kubernetes.io/docs/concepts/services-networking/service/) `lolling-chinchilla-cp-schema-registry` for clients to connect to Schema Registry.
-1. A [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/) which contains configuration for Prometheus JMX Exporter.
+
+1.
+
+A [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) `lolling-chinchilla-cp-schema-registry`
+which contains 1 Schema
+Registry [Pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/): `lolling-chinchilla-cp-schema-registry-58f854bd47-jxrcj`.
+
+1.
+
+A [Service](https://kubernetes.io/docs/concepts/services-networking/service/) `lolling-chinchilla-cp-schema-registry`
+for clients to connect to Schema Registry.
+
+1. A [ConfigMap](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/)
+   which contains configuration for Prometheus JMX Exporter.
 
 ## Configuration
 
 You can specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 
-Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+Alternatively, a YAML file that specifies the values for the parameters can be provided while
+installing the chart. For example,
 
 ```console
 helm install --name my-schema-registry -f my-values.yaml ./cp-schema-registry
@@ -84,97 +98,100 @@ helm install --name my-schema-registry -f my-values.yaml ./cp-schema-registry
 
 ### Schema Registry Deployment
 
-The configuration parameters in this section control the resources requested and utilized by the cp-schema-registry chart.
+The configuration parameters in this section control the resources requested and utilized by the
+cp-schema-registry chart.
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `replicaCount` | The number of Schema Registry Servers. | `1` |
+| Parameter      | Description                            | Default |
+|----------------|----------------------------------------|---------|
+| `replicaCount` | The number of Schema Registry Servers. | `1`     |
 
 ### Image
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `image` | Docker Image of Confluent Schema Registry. | `confluentinc/cp-schema-registry` |
-| `imageTag` | Docker Image Tag of Confluent Schema Registry. | `6.1.0` |
-| `imagePullPolicy` | Docker Image Tag of Confluent Schema Registry. | `IfNotPresent` |
-| `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
+| Parameter          | Description                                    | Default                                    |
+|--------------------|------------------------------------------------|--------------------------------------------|
+| `image`            | Docker Image of Confluent Schema Registry.     | `confluentinc/cp-schema-registry`          |
+| `imageTag`         | Docker Image Tag of Confluent Schema Registry. | `6.1.0`                                    |
+| `imagePullPolicy`  | Docker Image Tag of Confluent Schema Registry. | `IfNotPresent`                             |
+| `imagePullSecrets` | Secrets to be used for private registries.     | see [values.yaml](values.yaml) for details |
 
 ### Confluent Schema Registry Configuration
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `configurationOverrides` | Schema Registry [configuration](https://docs.confluent.io/current/schema-registry/docs/config.html) overrides in the dictionary format. | `{}` |
-| `customEnv` | Custom environmental variables | `{}` |
+| Parameter                | Description                                                                                                                             | Default |
+|--------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `configurationOverrides` | Schema Registry [configuration](https://docs.confluent.io/current/schema-registry/docs/config.html) overrides in the dictionary format. | `{}`    |
+| `customEnv`              | Custom environmental variables                                                                                                          | `{}`    |
 
 ### Port
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `servicePort` | The port on which the Schema Registry will be available and serving requests. | `8081` |
+| Parameter     | Description                                                                   | Default |
+|---------------|-------------------------------------------------------------------------------|---------|
+| `servicePort` | The port on which the Schema Registry will be available and serving requests. | `8081`  |
 
 ### Kafka
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `kafka.bootstrapServers` | Bootstrap Servers for Schema Registry | `""` |
+| Parameter                | Description                           | Default |
+|--------------------------|---------------------------------------|---------|
+| `kafka.bootstrapServers` | Bootstrap Servers for Schema Registry | `""`    |
 
 ### Confluent Schema Registry JVM Heap Options
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
+| Parameter     | Description                                        | Default               |
+|---------------|----------------------------------------------------|-----------------------|
 | `heapOptions` | The JVM Heap Options for Confluent Schema Registry | `"-Xms512M -Xmx512M"` |
 
 ### Resources
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `resources.requests.cpu` | The amount of CPU to request. | see [values.yaml](values.yaml) for details |
-| `resources.requests.memory` | The amount of memory to request. | see [values.yaml](values.yaml) for details |
-| `resources.limits.cpu` | The upper limit CPU usage for a Schema Registry Pod. | see [values.yaml](values.yaml) for details |
-| `resources.limits.memory` | The upper limit memory usage for a Schema Registry Pod. | see [values.yaml](values.yaml) for details |
+| Parameter                   | Description                                             | Default                                    |
+|-----------------------------|---------------------------------------------------------|--------------------------------------------|
+| `resources.requests.cpu`    | The amount of CPU to request.                           | see [values.yaml](values.yaml) for details |
+| `resources.requests.memory` | The amount of memory to request.                        | see [values.yaml](values.yaml) for details |
+| `resources.limits.cpu`      | The upper limit CPU usage for a Schema Registry Pod.    | see [values.yaml](values.yaml) for details |
+| `resources.limits.memory`   | The upper limit memory usage for a Schema Registry Pod. | see [values.yaml](values.yaml) for details |
 
 ### Annotations
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `podAnnotations` | Map of custom annotations to attach to the pod spec. | `{}` |
+| Parameter        | Description                                          | Default |
+|------------------|------------------------------------------------------|---------|
+| `podAnnotations` | Map of custom annotations to attach to the pod spec. | `{}`    |
 
 ### Security Context
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `securityContext.runAsUser` | All processes for the container will run with this user ID | 10001
-| `securityContext.runAsGroup` | All processes for the container will run with this primary group ID | 10001
-| `securityContext.fsGroup` | All processes for the container will run with this supplementary group ID | 10001
-| `securityContext.runAsNonRoot` | The kubelet will validate the image at runtime to make sure that it does not run as UID 0 (root) and won’t start the container if it does | true
+| Parameter                      | Description                                                                                                                               | Default |
+|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `securityContext.runAsUser`    | All processes for the container will run with this user ID                                                                                | 10001   |
+| `securityContext.runAsGroup`   | All processes for the container will run with this primary group ID                                                                       | 10001   |
+| `securityContext.fsGroup`      | All processes for the container will run with this supplementary group ID                                                                 | 10001   |
+| `securityContext.runAsNonRoot` | The kubelet will validate the image at runtime to make sure that it does not run as UID 0 (root) and won’t start the container if it does | true    |
 
 ### JMX Configuration
 
-| Parameter     | Description                           | Default |
-|---------------|---------------------------------------|---------|
-| `jmx.enabled` | Whether or not to expose JMX metrics. | `false` |
+| Parameter     | Description                                       | Default |
+|---------------|---------------------------------------------------|---------|
+| `jmx.enabled` | Whether or not to expose JMX metrics.             | `false` |
 | `jmx.port`    | The jmx port which JMX style metrics are exposed. | `5555`  |
 
 ### Prometheus JMX Exporter Configuration
 
-| Parameter                        | Description | Default                                                            |
-|----------------------------------| ----------- |--------------------------------------------------------------------|
+| Parameter                        | Description                                                                                                    | Default                                                            |
+|----------------------------------|----------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
 | `jmx.prometheus.enabled`         | Whether or not to install Prometheus JMX Exporter as a sidecar container and expose JMX metrics to Prometheus. | `false`                                                            |
-| `jmx.prometheus.image`           | Docker Image for Prometheus JMX Exporter container. | `solsson/kafka-prometheus-jmx-exporter@sha256`                     |
-| `jmx.prometheus.imageTag`        | Docker Image Tag for Prometheus JMX Exporter container. | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
-| `jmx.prometheus.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container. | `IfNotPresent`                                                     |
-| `jmx.prometheus.port`            | JMX Exporter Port which exposes metrics in Prometheus format for scraping. | `5556`                                                             |
-| `jmx.prometheus.resources`       | JMX Exporter resources configuration. | see [values.yaml](values.yaml) for details                         |
+| `jmx.prometheus.image`           | Docker Image for Prometheus JMX Exporter container.                                                            | `solsson/kafka-prometheus-jmx-exporter@sha256`                     |
+| `jmx.prometheus.imageTag`        | Docker Image Tag for Prometheus JMX Exporter container.                                                        | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
+| `jmx.prometheus.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container.                                                | `IfNotPresent`                                                     |
+| `jmx.prometheus.port`            | JMX Exporter Port which exposes metrics in Prometheus format for scraping.                                     | `5556`                                                             |
+| `jmx.prometheus.resources`       | JMX Exporter resources configuration.                                                                          | see [values.yaml](values.yaml) for details                         |
 
-### Datadog JMX Exporter Configuration
+### Datadog Configuration
 
-| Parameter                        | Description                                                                                              | Default |
-|----------------------------------|----------------------------------------------------------------------------------------------------------|---------|
-| `jmx.datadog.enabled`            | Whether or not to annotate the pod for autodiscovery by the Datadog agent expose JMX metrics to Datadog. | `false` |
+| Parameter                          | Description                                                                                                 | Default |
+|------------------------------------|-------------------------------------------------------------------------------------------------------------|---------|
+| `datadog.jmx.enabled`              | Whether or not to annotate the pod for autodiscovery by the Datadog agent to expose JMX metrics to Datadog. | `false` |
+| `datadog.jmx.max_returned_metrics` | The maximum number of JMX metrics to send to Datadog.                                                       | `false` |
+| `datadog.logs.enabled`             | Whether or not to annotate the pod for autodiscovery by the Datadog agent to send logs to Datadog.          | `false` |
 
 ### Deployment Topology
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `nodeSelector` | Dictionary containing key-value-pairs to match labels on nodes. When defined pods will only be scheduled on nodes, that have each of the indicated key-value pairs as labels. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}`
-| `tolerations`| Array containing taint references. When defined, pods can run on nodes, which would otherwise deny scheduling. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `{}`
+| Parameter      | Description                                                                                                                                                                                                                                                                                                          | Default |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `nodeSelector` | Dictionary containing key-value-pairs to match labels on nodes. When defined pods will only be scheduled on nodes, that have each of the indicated key-value pairs as labels. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}`    | 
+| `tolerations`  | Array containing taint references. When defined, pods can run on nodes, which would otherwise deny scheduling. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)                                                           | `{}`    |

--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       labels:
         app: {{ template "cp-schema-registry.name" . }}
         release: {{ .Release.Name }}
-      {{- if or .Values.podAnnotations .Values.jmx.prometheus.enabled .Values.jmx.datadog.enabled }}
+      {{- if or .Values.podAnnotations .Values.jmx.prometheus.enabled .Values.datadog.jmx.enabled .Values.datadog.logs.enabled}}
       annotations:
       {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
@@ -31,7 +31,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.jmx.prometheus.port | quote }}
       {{- end }}
-      {{- if .Values.jmx.datadog.enabled }}
+      {{- if .Values.datadog.jmx.enabled }}
         ad.datadoghq.com/{{ template "cp-schema-registry.fullname" . }}.check_names: '["confluent_platform"]'
         ad.datadoghq.com/{{ template "cp-schema-registry.fullname" . }}.init_configs: '[{"is_jmx":true,"collect_default_metrics":true}]'
         ad.datadoghq.com/{{ template "cp-schema-registry.fullname" . }}.instances: |
@@ -39,12 +39,12 @@ spec:
             {
               "host":"%%host%%",
               "port":{{ .Values.jmx.port | quote }},
-              "max_returned_metrics":999
+              "max_returned_metrics":{{ .Values.datadog.jmx.max_returned_metrics }}
             }
           ]
-        {{- if .Values.jmx.datadog.logs.enabled }}
+      {{- end }}
+      {{- if .Values.datadog.logs.enabled }}
         ad.datadoghq.com/{{ template "cp-schema-registry.fullname" . }}.logs: '[{"source":"confluent_platform","service":"confluent_platform"}]'
-        {{- end }}
       {{- end }}
       {{- end }}
     spec:

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -98,7 +98,11 @@ jmx:
     ## Resources configuration for the JMX exporter container.
     ## See the `resources` documentation above for details.
     resources: { }
-  datadog:
-    enabled: true
-    logs:
-      enabled: false
+
+# Datadog configuration
+datadog:
+  jmx:
+    enabled: false
+    max_returned_metrics: 999
+  logs:
+    enabled: false


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Restructured chart values such that jmx.datadog -> datadog.jmx
* Relocated the erroneous jmx.datadog.logs -> datadog.logs
* Exposed the datadog.jmx.max_returned_metrics as a config option from calling charts
* Cleaned up deployments to uncouple jmx and logs dependency ito annotations
* Aligned deployments to new naming
* Updated READMEs to include new config options and removed the old ones
* Reformatted READMEs to have correct MD formatting
